### PR TITLE
Fix chat scroll memory on open

### DIFF
--- a/src/lib/chat-cache.ts
+++ b/src/lib/chat-cache.ts
@@ -75,6 +75,15 @@ class ChatCache {
     if (entry) {
       entry.scrollPosition = position;
       entry.lastScrollTime = Date.now();
+    } else {
+      // Create a minimal entry just for scroll position if messages aren't cached yet
+      this.cache.set(conversationId, {
+        messages: [],
+        lastFetched: Date.now(),
+        isComplete: false,
+        scrollPosition: position,
+        lastScrollTime: Date.now()
+      });
     }
   }
 


### PR DESCRIPTION
Fix scroll memory in chat by correctly handling Radix UI's ScrollArea viewport.

Previously, scroll events were attached to an inner div instead of the `ScrollArea`'s actual viewport, leading to unreliable scroll position saving and restoration. This PR ensures proper event listener attachment, debounced saving, and timed restoration to maintain scroll state across conversations.

---
<a href="https://cursor.com/background-agent?bcId=bc-95fb919a-ade4-422a-a1fb-56c9d5d82fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95fb919a-ade4-422a-a1fb-56c9d5d82fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

